### PR TITLE
Implemented the Keep Alive RESTful configuration 

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -4,6 +4,7 @@
         <config name="url">localhost</config>
         <config name="port">8765</config>
         <config name="verbose">INFO</config>
+        <config name="keep_alive">True</config>
     </RESTful>
     <XBee>
         <config name="baud">115200</config>
@@ -14,7 +15,7 @@
         <config name="ip">127.0.0.1</config>
         <config name="port">19900</config>
         <config name="verbose">INFO</config>
-        <config name="emulation">False</config>
+        <config name="emulation">True</config>
         <config name="database">staging</config>
     </server>
     <emulation>
@@ -53,6 +54,6 @@
             <sensor name="accel_fl_z_mg">int(500*math.sin(math.radians(x*10))+1000)</sensor>
         </config>
         <config name="delay">1</config>
-        <config name="verbose">DEBUG</config>
+        <config name="verbose">INFO</config>
     </emulation>
 </config>

--- a/server.py
+++ b/server.py
@@ -346,7 +346,7 @@ class Server:
         finally:
             self._logger.info("Stopped")
 
-    async def _restful_serve(self, request: restful.RestfulRequest):
+    def _restful_serve(self, request: restful.RestfulRequest) -> dict:
         """
         Serve a RESTful request.
         :param request: The RESTful request.
@@ -384,7 +384,7 @@ class Server:
                             for sensor_time, sensor_val in sensor_data:
                                 response[sensor].extend([{"time": sensor_time, "value": sensor_val}])
 
-        await request.respond(response)
+        return response
 
     def __exit__(self, exc_type: Optional[Exception], exc_val: Optional[Exception], exc_tb: Optional[Exception]) \
             -> None:


### PR DESCRIPTION
The RESTful websocket closing after a response is now configurable through the `keep_alive` configuration in `config.xml`.

closes #45 