### PR TITLE
Issue 46 further restful endpoints

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -18,13 +18,143 @@
         <config name="emulation">True</config>
         <config name="database">staging</config>
     </server>
+    <sensors>
+        <sensor name="rpm">
+            <config name="enable">True</config>
+            <config name="group">Core</config>
+        </sensor>
+        <sensor name="water_temp_c">
+            <config name="enable">True</config>
+            <config name="group">Core</config>
+        </sensor>
+        <sensor name="tps_perc">
+            <config name="enable">True</config>
+            <config name="group">Core</config>
+        </sensor>
+        <sensor name="battery_mv">
+            <config name="enable">True</config>
+            <config name="group">Core</config>
+        </sensor>
+        <sensor name="ext_5v_mv">
+            <config name="enable">True</config>
+            <config name="group">Core</config>
+        </sensor>
+        <sensor name="fuel_flow">
+            <config name="enable">True</config>
+            <config name="group">Core</config>
+        </sensor>
+        <sensor name="lambda">
+            <config name="enable">True</config>
+            <config name="group">Core</config>
+        </sensor>
+        <sensor name="speed_kph">
+            <config name="enable">True</config>
+            <config name="group">Core</config>
+        </sensor>
+        <sensor name="evo_scan_1">
+            <config name="enable">True</config>
+            <config name="group">Aero</config>
+        </sensor>
+        <sensor name="evo_scan_2">
+            <config name="enable">True</config>
+            <config name="group">Aero</config>
+        </sensor>
+        <sensor name="evo_scan_3">
+            <config name="enable">True</config>
+            <config name="group">Aero</config>
+        </sensor>
+        <sensor name="evo_scan_4">
+            <config name="enable">True</config>
+            <config name="group">Aero</config>
+        </sensor>
+        <sensor name="evo_scan_5">
+            <config name="enable">True</config>
+            <config name="group">Aero</config>
+        </sensor>
+        <sensor name="evo_scan_6">
+            <config name="enable">True</config>
+            <config name="group">Aero</config>
+        </sensor>
+        <sensor name="evo_scan_7">
+            <config name="enable">True</config>
+            <config name="group">Aero</config>
+        </sensor>
+        <sensor name="status_ecu_connected">
+            <config name="enable">True</config>
+            <config name="group">Diagnostic</config>
+        </sensor>
+        <sensor name="status_engine">
+            <config name="enable">True</config>
+            <config name="group">Diagnostic</config>
+        </sensor>
+        <sensor name="status_battery">
+            <config name="enable">True</config>
+            <config name="group">Diagnostic</config>
+        </sensor>
+        <sensor name="status_logging">
+            <config name="enable">True</config>
+            <config name="group">Diagnostic</config>
+        </sensor>
+        <sensor name="inj_time">Power
+            <config name="enable">True</config>
+            <config name="group">Diagnostic</config>
+        </sensor>
+        <sensor name="inj_duty_cycle">
+            <config name="enable">True</config>
+            <config name="group">Power Train</config>
+        </sensor>
+        <sensor name="lambda_pid_adj">
+            <config name="enable">True</config>
+            <config name="group">Power Train</config>
+        </sensor>
+        <sensor name="lambda_pid_target">
+            <config name="enable">True</config>
+            <config name="group">Power Train</config>
+        </sensor>
+        <sensor name="advance">
+            <config name="enable">True</config>
+            <config name="group">Power Train</config>
+        </sensor>
+        <sensor name="ride_height_fl_cm">
+            <config name="enable">True</config>
+            <config name="group">Suspension</config>
+        </sensor>
+        <sensor name="ride_height_fr_cm">
+            <config name="enable">True</config>
+            <config name="group">Suspension</config>
+        </sensor>
+        <sensor name="ride_height_flw_cm">
+            <config name="enable">True</config>
+            <config name="group">Suspension</config>
+        </sensor>
+        <sensor name="ride_height_rear_cm">
+            <config name="enable">True</config>
+            <config name="group">Suspension</config>
+        </sensor>
+        <sensor name="lap_time_s">
+            <config name="enable">True</config>
+            <config name="group">Misc</config>
+        </sensor>
+        <sensor name="accel_fl_x_mg">
+            <config name="enable">True</config>
+            <config name="group">Misc</config>
+        </sensor>
+        <sensor name="accel_fl_y_mg">
+            <config name="enable">True</config>
+            <config name="group">Misc</config>
+        </sensor>
+        <sensor name="accel_fl_z_mg">
+            <config name="enable">True</config>
+            <config name="group">Misc</config>
+        </sensor>
+    </sensors>
     <emulation>
         <config name="sensors">
             <sensor name="rpm">int(5000 * math.sin(math.radians(x * 10)) + 5000)</sensor>
             <sensor name="water_temp_c">random.randint(80,100)</sensor>
             <sensor name="tps_perc">int(50*math.sin(math.radians(x*10))+50)</sensor>
             <sensor name="battery_mv">random.randint(11900,12100)</sensor>
-            <sensor name="ext_5v_mv">random.randint(4900,5100) </sensor>
+            <sensor name="ext_5v_mv">random.randint(4900,5100)</sensor>
             <sensor name="fuel_flow">int(25*math.sin(math.radians(x*10))+25)</sensor>
             <sensor name="lambda">int(25*math.sin(math.radians(x*10))+50)</sensor>
             <sensor name="speed_kph">int(150*math.sin(math.radians(x*10))+150)</sensor>

--- a/server.py
+++ b/server.py
@@ -371,11 +371,15 @@ class Server:
                 if len(request.get_datasets()) == 1:
                     # /sensors
                     for sensor, config in self._config["sensors"].items():
-                        sensor_data = self._database.select_sensor_data_top_n_entries(sensor, amount)
-                        if len(sensor_data) > 0:
-                            response[sensor] = []
-                            for sensor_time, sensor_val in sensor_data:
-                                response[sensor].extend([{"time": sensor_time, "value": sensor_val}])
+                        if config["group"] not in response:
+                            response[config["group"]] = {}
+                        if config["enable"]:
+                            sensor_data = self._database.select_sensor_data_top_n_entries(sensor, amount)
+                            if len(sensor_data) > 0:
+                                response[config["group"]][sensor] = []
+                                for sensor_time, sensor_val in sensor_data:
+                                    response[config["group"]][sensor].extend(
+                                        [{"time": sensor_time, "value": sensor_val}])
 
         return response
 

--- a/serverdatabase.py
+++ b/serverdatabase.py
@@ -98,6 +98,23 @@ class ServerDatabase:
 
         return data
 
+    def select_sensor_data_top_n_entries_and_between_times(self, sensor: str, n: int, times: list) -> list:
+        """
+        Get top n sensor data points from the sensor table between time times (time column included)
+        :param sensor: The sensor to select from.
+        :param n The maximum number of rows to return.
+        :param times The times between to select from.
+        :return A list of sensor data tuples for up to the last n points.
+        """
+        data = []
+        cur = self._con.cursor()
+
+        for row in cur.execute(
+                f"SELECT * FROM {sensor} WHERE time BETWEEN {times[0]} AND {times[1]} ORDER BY time DESC LIMIT {n}"):
+            data.append(row)
+
+        return data
+
     def commit(self):
         """
         Commit the database to file.


### PR DESCRIPTION
Implemented the wanted features in #46.

- `GET /sensors?` will return a dictionary that contains every (enabled) sensor grouped by group name along with its sensor data (up to 99 points).
- `GET /sensors/<group>` (e.g.`GET /sensors/Core` ) will only return the sensors that correspond to the `Core` group (the dictionary is of the form `{"Core": {<sensors>}}`).
- `Get /sensors?amount=<n>&timesince=<epoch>`  will return a dictionary that contains every (enabled) sensor grouped by group name along with its sensor data (up to n points and only points that are between <epoch> and the current <epoch> measured at the server). Groups also work e.g. `Get /sensors/Core?amount=<n>&timesince=<epoch>`.

closes #46
closes #39 